### PR TITLE
Add support for Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama, Ollama,  (100+LLMs)

### DIFF
--- a/parallel_parrot/openai_api.py
+++ b/parallel_parrot/openai_api.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from typing import List, Optional, Tuple, Union
+import litellm
 
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp_retry import RetryClient, JitterRetry
@@ -196,16 +197,9 @@ async def do_chat_completion_simple(
         function_call=function_call,
     )
     logger.info(f"POST to {OPENAI_CHAT_COMPLETIONS_URL} with {payload=}")
-    async with client_session.post(
-        OPENAI_CHAT_COMPLETIONS_URL, json=payload
-    ) as response:
-        logger.info(
-            f"Response {response.status=} {response.reason=} from {payload=} {response.headers=}"
-        )
-        response.raise_for_status()
-        response_result = await response.json()
-        logger.info(f"Response {response_result=} from {payload=}")
-        return (response_result, dict(response.headers))
+    response_result = await litellm.acompletion(**payload)
+    logger.info(f"Response {response_result=} from {payload=}")
+    return (response_result, response_result)
 
 
 def parse_chat_completion_message_and_usage(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pandas = { version = "*", optional = true }
 tiktoken = "^0.4.0"
 dataclass-utils = "^0.7.23"
 asyncio-anywhere = "^0.1.2"
+litellm = "^0.1.697"
 
 [tool.poetry.group.dev.dependencies]
 aioresponses = { git = "https://github.com/pnuckowski/aioresponses.git", rev = "b444d724fd1d5b5db0a706960381bcffe2e44f7d" }


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```